### PR TITLE
refactor: remove async as it is not used

### DIFF
--- a/src/condition-circle.js
+++ b/src/condition-circle.js
@@ -10,7 +10,7 @@ const isToken = (key) => {
   return key.toLowerCase().indexOf('token') !== -1
 }
 
-async function conditionCircle (pluginConfig, args) {
+function conditionCircle (pluginConfig, args) {
   const options = args.options
   const branch = options.branch
 


### PR DESCRIPTION
The function is all synchronous, so why use async at all? Fails for earlier versions of node