### PR TITLE
Semantic release 11 fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,9 @@
     "url": "https://github.com/bahmutov/condition-circle/issues"
   },
   "homepage": "https://github.com/bahmutov/condition-circle#readme",
+  "peerDependencies": {
+    "semantic-release": "^11.0.0"
+  },
   "dependencies": {
     "@semantic-release/error": "2.1.0",
     "cross-spawn": "5.1.0",
@@ -51,7 +54,7 @@
   },
   "devDependencies": {
     "pre-git": "3.16.0",
-    "semantic-release": "11.0.1",
+    "semantic-release": "^11.0.0",
     "standard": "10.0.3"
   },
   "config": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "release": {
     "debug": false,
-    "analyzeCommits": "simple-commit-message",    
+    "analyzeCommits": "./simple-commit-message.js",    
     "verifyConditions": [
       "./src/condition-circle.js",
       "@semantic-release/npm", 

--- a/simple-commit-message.js
+++ b/simple-commit-message.js
@@ -1,0 +1,5 @@
+const { promisify } = require('util');
+const simpleCommitMessage = require('simple-commit-message');
+
+module.exports = promisify(simpleCommitMessage);
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -2664,9 +2664,9 @@ safe-env@1.2.0:
   dependencies:
     ramda "0.22.1"
 
-semantic-release@11.0.1:
-  version "11.0.1"
-  resolved "https://registry.yarnpkg.com/semantic-release/-/semantic-release-11.0.1.tgz#9103a9d43968db864cf9f725c2a3b4d8ab0cdc47"
+semantic-release@^11.0.0:
+  version "11.0.2"
+  resolved "https://registry.yarnpkg.com/semantic-release/-/semantic-release-11.0.2.tgz#2a09baa33a0e41926ac3290c8b110d22a5ba2a48"
   dependencies:
     "@semantic-release/commit-analyzer" "^5.0.0"
     "@semantic-release/condition-travis" "^7.0.0"


### PR DESCRIPTION
##### chore: add `semantic-release` 11.x to `peerDependencies`
To signal what version of `semantic-release` this plugin is compatible with.

##### fix: wrap `simple-commit-message` to work w/ `semantic-release` 11.x
This is a temporary workaround until `simple-commit-message` has been updated to work with `semantic-release`'s new plugin format.