### PR TITLE
break: force breaking change for `semantic-release` 11.x upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ if there is no new release to be published, the build is still ok.
 ```yaml
 machine:
   node:
-    version: "0.12"
+    version: "8"
 test:
   override:
     - npm test


### PR DESCRIPTION
BREAKING CHANGE: The plugin API of `semantic-release` 11.x isn't compatible with previous versions of `condition-circle`.